### PR TITLE
Fix test failed after test_reset_password if user use own password

### DIFF
--- a/backend/app/tests/api/routes/test_login.py
+++ b/backend/app/tests/api/routes/test_login.py
@@ -73,7 +73,7 @@ def test_reset_password(
     client: TestClient, superuser_token_headers: dict[str, str], db: Session
 ) -> None:
     token = generate_password_reset_token(email=settings.FIRST_SUPERUSER)
-    data = {"new_password": "changethis", "token": token}
+    data = {"new_password": settings.FIRST_SUPERUSER_PASSWORD, "token": token}
     r = client.post(
         f"{settings.API_V1_STR}/reset-password/",
         headers=superuser_token_headers,


### PR DESCRIPTION
If user set password of FIRST_SUPERUSER_PASSWORD to a different value of "changethis" in .env file, after run test_reset_password case, the password will be changed to "changethis" becasue it hardcorded in this testcase.  
Following testcases will all be failed because of wrong password. 
Change it to reset to password in .env file.